### PR TITLE
SplunkSender: support urllib3 >=2.0.0

### DIFF
--- a/splunk_data_sender/__init__.py
+++ b/splunk_data_sender/__init__.py
@@ -126,7 +126,7 @@ class SplunkSender:
         log.debug("Preparing to create a Requests session")
         retry = Retry(total=self.retry_count,
                       backoff_factor=self.retry_backoff,
-                      method_whitelist=False,  # Retry for any HTTP verb
+                      allowed_methods=False,  # Retry for any HTTP verb
                       status_forcelist=[500, 502, 503, 504],
                       redirect=1)
         self.session.mount(f"{self.protocol}://", HTTPAdapter(max_retries=retry))


### PR DESCRIPTION
The method_whitelist method has been deprecated in urllib3 v1.26, and removed since then
It has been replaced with allowed_methods=

See https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#200-2023-04-26 for more details